### PR TITLE
Add points types to the ranking table

### DIFF
--- a/.github/workflows/nextLint.yml
+++ b/.github/workflows/nextLint.yml
@@ -1,0 +1,33 @@
+name: Next Lint Check
+#
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '20' # Your node version, default 20 in 2024
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Run ESLint
+        run: yarn lint

--- a/src/api/type.d.ts
+++ b/src/api/type.d.ts
@@ -65,6 +65,9 @@ interface IRankingData {
   sevenSymbolAmount: number;
   eightSymbolAmount: number;
   nineSymbolAmount: number;
+  tenSymbolAmount: number;
+  elevenSymbolAmount: number;
+  twelveSymbolAmount: number;
   inviteFollowersNumber: number;
   inviteRate: number;
   thirdFollowersNumber: number;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,4 +12,12 @@ export enum NetworkType {
 export const SECONDS_60 = 60000;
 
 export const mainChain = 'AELF';
-export const SGR_5_TOOL_TIP = 'Points Earned from Cat Adopting';
+export const SGR_1_TOOL_TIP = 'New user joining Schrödinger';
+export const SGR_2_TOOL_TIP = 'Perpetual Points (Auto rewards generated every second)';
+export const SGR_3_TOOL_TIP = 'Customised link registration';
+export const SGR_4_TOOL_TIP = 'Joining community campaigns';
+export const SGR_5_TOOL_TIP = 'Adopting cats';
+export const SGR_6_TOOL_TIP = 'Rerolling cats';
+export const SGR_9_TOOL_TIP = '$SGR-1 holdings on the aelf blockchain';
+export const SGR_10_TOOL_TIP = 'Provide LP for SGR/USDT on Uniswap';
+export const SGR_11_TOOL_TIP = 'Provide LP for SGR/ELF on Awaken';

--- a/src/pageComponents/EarnTokenList/column.tsx
+++ b/src/pageComponents/EarnTokenList/column.tsx
@@ -3,14 +3,22 @@ import { ColumnsType } from 'antd/es/table';
 import CommonCopy from 'components/CommonCopy';
 import SkeletonImage from 'components/SkeletonImage';
 import { IEarnToken } from 'types/earnToke';
-import { formatTokenPrice } from 'utils/format';
 import { OpenLink } from 'assets/images/icons/index';
-import { Tooltip } from 'aelf-design';
-import { ReactComponent as QuestionIconComp } from 'assets/images/icons/questionCircleOutlined.svg';
-import BigNumber from 'bignumber.js';
-import { EarnAmountCount } from 'pageComponents/ranking/comps/EarnAmount';
+import { EarnAmountCount } from 'pageComponents/ranking/comps/EarnAmountDynamic';
 import { RoleTypeName } from 'types/role';
-import { SGR_5_TOOL_TIP } from 'constants/index';
+import {
+  SGR_10_TOOL_TIP,
+  SGR_11_TOOL_TIP,
+  SGR_1_TOOL_TIP,
+  SGR_2_TOOL_TIP,
+  SGR_3_TOOL_TIP,
+  SGR_4_TOOL_TIP,
+  SGR_5_TOOL_TIP,
+  SGR_6_TOOL_TIP,
+  SGR_9_TOOL_TIP,
+} from 'constants/index';
+import PointsTitle from 'pageComponents/ranking/comps/PointsTitle';
+import EarnAmount from 'pageComponents/ranking/comps/EarnAmount';
 
 export const columns: (params?: { showShareModal?: (data: IEarnToken) => void }) => ColumnsType<IEarnToken> = ({
   showShareModal,
@@ -77,59 +85,80 @@ export const columns: (params?: { showShareModal?: (data: IEarnToken) => void })
     //   ),
     // },
     {
-      title: (
-        <div className="flex items-center">
-          <Tooltip title="Points Earned from New User Account Creation">
-            <QuestionIconComp className="w-4 h-4 mr-1 cursor-pointer" width={16} height={16} />
-          </Tooltip>
-          <span>XPSGR-1</span>
-        </div>
-      ),
-      dataIndex: 'firstSymbolAmount',
-      key: 'firstSymbolAmount',
+      title: <PointsTitle title="XPSGR-11" tip={SGR_11_TOOL_TIP} />,
+      dataIndex: 'elevenSymbolAmount',
+      key: 'elevenSymbolAmount',
       sorter: true,
-      render: (amount) => {
-        const text = BigNumber(amount)
-          .dividedBy(10 ** 8)
-          .toNumber();
-        return <span className=" text-neutralPrimary text-base font-medium">{formatTokenPrice(text)}</span>;
-      },
+      sortDirections: ['descend', 'ascend', 'descend'],
+      defaultSortOrder: 'descend',
+      render: (amount) => <EarnAmount amount={amount} />,
     },
     {
-      title: (
-        <div className="flex items-center">
-          <Tooltip title="Perpetual Points (Auto rewards generated every second)">
-            <QuestionIconComp className="w-4 h-4 mr-1 cursor-pointer" width={16} height={16} />
-          </Tooltip>
-          <span>XPSGR-2</span>
-        </div>
-      ),
+      title: <PointsTitle title="XPSGR-10" tip={SGR_10_TOOL_TIP} />,
+      dataIndex: 'tenSymbolAmount',
+      key: 'tenSymbolAmount',
+      sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
+    },
+    {
+      title: <PointsTitle title="XPSGR-9" tip={SGR_9_TOOL_TIP} />,
+      dataIndex: 'nineSymbolAmount',
+      key: 'nineSymbolAmount',
+      sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
+    },
+    {
+      title: <PointsTitle title="XPSGR-6" tip={SGR_6_TOOL_TIP} />,
+      dataIndex: 'sixSymbolAmount',
+      key: 'sixSymbolAmount',
+      sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
+    },
+    {
+      title: <PointsTitle title="XPSGR-5" tip={SGR_5_TOOL_TIP} />,
+      dataIndex: 'fiveSymbolAmount',
+      key: 'fiveSymbolAmount',
+      sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
+    },
+    {
+      title: <PointsTitle title="XPSGR-4" tip={SGR_4_TOOL_TIP} />,
+      dataIndex: 'fourSymbolAmount',
+      key: 'fourSymbolAmount',
+      sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
+    },
+    {
+      title: <PointsTitle title="XPSGR-3" tip={SGR_3_TOOL_TIP} />,
+      dataIndex: 'thirdSymbolAmount',
+      key: 'thirdSymbolAmount',
+      sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
+    },
+    {
+      title: <PointsTitle title="XPSGR-2" tip={SGR_2_TOOL_TIP} />,
       dataIndex: 'secondSymbolAmount',
       key: 'secondSymbolAmount',
       width: 180,
       sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
       render: (secondSymbolAmount, item) => (
         <EarnAmountCount {...item} amount={secondSymbolAmount} className="text-base" />
       ),
     },
     {
-      title: (
-        <div className="flex items-center">
-          <Tooltip title={SGR_5_TOOL_TIP}>
-            <QuestionIconComp className="w-4 h-4 mr-1 cursor-pointer" width={16} height={16} />
-          </Tooltip>
-          <span>XPSGR-5</span>
-        </div>
-      ),
-      dataIndex: 'fiveSymbolAmount',
-      key: 'fiveSymbolAmount',
+      title: <PointsTitle title="XPSGR-1" tip={SGR_1_TOOL_TIP} />,
+      dataIndex: 'firstSymbolAmount',
+      key: 'firstSymbolAmount',
       sorter: true,
-      render: (amount) => {
-        const text = BigNumber(amount)
-          .dividedBy(10 ** 8)
-          .toNumber();
-        return <span className=" text-neutralPrimary text-base font-medium">{formatTokenPrice(text)}</span>;
-      },
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
     },
   ];
 };

--- a/src/pageComponents/EarnTokenList/index.tsx
+++ b/src/pageComponents/EarnTokenList/index.tsx
@@ -54,7 +54,7 @@ export default function EarnTokenList() {
       skipCount: (pageNum - 1) * pageSize,
       maxResultCount: pageSize,
       Address: wallet.address,
-      sortingKeyWord: sortField || sortType.firstSymbolAmount,
+      sortingKeyWord: sortField || sortType.elevenSymbolAmount,
       sorting: String(fieldOrder).replace('end', '').toUpperCase(),
     };
     if (!fieldOrder) {
@@ -67,7 +67,7 @@ export default function EarnTokenList() {
     console.log('sorter', sorter, pageSize, page);
     pageSize && setPageSize(pageSize);
     page && setPageNum(page);
-    sorter && setSortField(sortType[sorter.field] || 'FirstSymbolAmount');
+    sorter && setSortField(sortType[sorter.field] || sortType.elevenSymbolAmount);
     sorter && setFieldOrder(sorter.order);
   };
 

--- a/src/pageComponents/ranking/comps/EarnAmount.tsx
+++ b/src/pageComponents/ranking/comps/EarnAmount.tsx
@@ -1,47 +1,15 @@
-import { useTimeoutFn, useUnmount } from 'react-use';
-import { useState } from 'react';
-import { formatTokenPrice } from 'utils/format';
 import BigNumber from 'bignumber.js';
-import clsx from 'clsx';
+import { useMemo } from 'react';
+import { formatTokenPrice } from 'utils/format';
 
-interface IEarnAmountCountProps {
-  updateTime: number;
-  amount: number | string;
-  rate: number;
-  followersNumber: number;
-  inviteRate: number;
-  inviteFollowersNumber: number;
-  className?: string;
-}
-function computeAmountCount({
-  updateTime,
-  amount,
-  rate,
-  followersNumber,
-  inviteRate,
-  inviteFollowersNumber,
-}: IEarnAmountCountProps) {
-  const times = Math.floor(Math.max(0, Date.now() - updateTime) / 1000);
+export default function EarnAmount({ amount }: { amount: string | number }) {
+  const amountText = useMemo(() => {
+    return formatTokenPrice(
+      BigNumber(amount || 0)
+        .dividedBy(10 ** 8)
+        .toNumber(),
+    );
+  }, [amount]);
 
-  return BigNumber(times)
-    .times(rate)
-    .times(followersNumber)
-    .plus(BigNumber(times).times(inviteRate).times(inviteFollowersNumber))
-    .plus(BigNumber(amount).dividedBy(10 ** 8))
-    .toString();
-}
-
-export function EarnAmountCount({ className, ...props }: IEarnAmountCountProps) {
-  const [count, setCount] = useState(computeAmountCount(props));
-
-  const [, cancel, reset] = useTimeoutFn(() => {
-    setCount(computeAmountCount(props));
-    reset();
-  }, 1000);
-
-  useUnmount(() => {
-    cancel();
-  });
-
-  return <span className={clsx('font-medium text-neutralPrimary', className)}>{formatTokenPrice(count)}</span>;
+  return <span className="text-neutralPrimary text-base font-medium">{amountText}</span>;
 }

--- a/src/pageComponents/ranking/comps/EarnAmountDynamic.tsx
+++ b/src/pageComponents/ranking/comps/EarnAmountDynamic.tsx
@@ -1,0 +1,47 @@
+import { useTimeoutFn, useUnmount } from 'react-use';
+import { useState } from 'react';
+import { formatTokenPrice } from 'utils/format';
+import BigNumber from 'bignumber.js';
+import clsx from 'clsx';
+
+interface IEarnAmountCountProps {
+  updateTime: number;
+  amount: number | string;
+  rate: number;
+  followersNumber: number;
+  inviteRate: number;
+  inviteFollowersNumber: number;
+  className?: string;
+}
+function computeAmountCount({
+  updateTime,
+  amount,
+  rate,
+  followersNumber,
+  inviteRate,
+  inviteFollowersNumber,
+}: IEarnAmountCountProps) {
+  const times = Math.floor(Math.max(0, Date.now() - updateTime) / 1000);
+
+  return BigNumber(times)
+    .times(rate)
+    .times(followersNumber)
+    .plus(BigNumber(times).times(inviteRate).times(inviteFollowersNumber))
+    .plus(BigNumber(amount).dividedBy(10 ** 8))
+    .toString();
+}
+
+export function EarnAmountCount({ className, ...props }: IEarnAmountCountProps) {
+  const [count, setCount] = useState(computeAmountCount(props));
+
+  const [, cancel, reset] = useTimeoutFn(() => {
+    setCount(computeAmountCount(props));
+    reset();
+  }, 1000);
+
+  useUnmount(() => {
+    cancel();
+  });
+
+  return <span className={clsx('font-medium text-neutralPrimary', className)}>{formatTokenPrice(count)}</span>;
+}

--- a/src/pageComponents/ranking/comps/PointsTitle.tsx
+++ b/src/pageComponents/ranking/comps/PointsTitle.tsx
@@ -1,0 +1,13 @@
+import { Tooltip } from 'aelf-design';
+import { ReactComponent as QuestionIconComp } from 'assets/images/icons/questionCircleOutlined.svg';
+
+export default function PointsTitle({ title, tip }: { title: string; tip: string }) {
+  return (
+    <div className="flex items-center">
+      <Tooltip title={tip}>
+        <QuestionIconComp className="w-4 h-4 mr-1 cursor-pointer" width={16} height={16} />
+      </Tooltip>
+      <span>{title}</span>
+    </div>
+  );
+}

--- a/src/pageComponents/ranking/comps/RankingTable.tsx
+++ b/src/pageComponents/ranking/comps/RankingTable.tsx
@@ -3,14 +3,23 @@ import { Table, Tooltip, Pagination } from 'aelf-design';
 import type { TableColumnsType } from 'antd';
 import { ConfigProvider } from 'antd';
 import { ReactComponent as QuestionIconComp } from 'assets/images/icons/questionCircleOutlined.svg';
-
-import { EarnAmountCount } from './EarnAmount';
+import { EarnAmountCount } from './EarnAmountDynamic';
 import CommonCopy from 'components/CommonCopy';
 import { SorterResult } from 'antd/es/table/interface';
-import BigNumber from 'bignumber.js';
-import { formatTokenPrice } from 'utils/format';
 import { OmittedType, addPrefixSuffix, getOmittedStr } from 'utils/addressFormatting';
-import { SGR_5_TOOL_TIP } from 'constants/index';
+import {
+  SGR_10_TOOL_TIP,
+  SGR_11_TOOL_TIP,
+  SGR_1_TOOL_TIP,
+  SGR_2_TOOL_TIP,
+  SGR_3_TOOL_TIP,
+  SGR_4_TOOL_TIP,
+  SGR_5_TOOL_TIP,
+  SGR_6_TOOL_TIP,
+  SGR_9_TOOL_TIP,
+} from 'constants/index';
+import PointsTitle from './PointsTitle';
+import EarnAmount from './EarnAmount';
 interface IDappTableProps {
   dataSource: IRankingData[];
   loading: boolean;
@@ -86,59 +95,80 @@ export function RankingTable({
       },
     },
     {
-      title: (
-        <div className="flex items-center">
-          <Tooltip title="Points Earned from New User Account Creation">
-            <QuestionIconComp className="w-4 h-4 mr-1 cursor-pointer" width={16} height={16} />
-          </Tooltip>
-          <span>XPSGR-1</span>
-        </div>
-      ),
-      dataIndex: 'firstSymbolAmount',
-      key: 'firstSymbolAmount',
+      title: <PointsTitle tip={SGR_11_TOOL_TIP} title="XPSGR-11" />,
+      dataIndex: 'elevenSymbolAmount',
+      key: 'elevenSymbolAmount',
       sorter: true,
-      render: (amount) => {
-        const text = BigNumber(amount)
-          .dividedBy(10 ** 8)
-          .toNumber();
-        return <span className=" text-neutralPrimary text-base font-medium">{formatTokenPrice(text)}</span>;
-      },
+      sortDirections: ['descend', 'ascend', 'descend'],
+      defaultSortOrder: 'descend',
+      render: (amount) => <EarnAmount amount={amount} />,
     },
     {
-      title: (
-        <div className="flex items-center">
-          <Tooltip title="Perpetual Points (Auto rewards generated every second)">
-            <QuestionIconComp className="w-4 h-4 mr-1 cursor-pointer" width={16} height={16} />
-          </Tooltip>
-          <span>XPSGR-2</span>
-        </div>
-      ),
+      title: <PointsTitle tip={SGR_10_TOOL_TIP} title="XPSGR-10" />,
+      dataIndex: 'tenSymbolAmount',
+      key: 'tenSymbolAmount',
+      sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
+    },
+    {
+      title: <PointsTitle tip={SGR_9_TOOL_TIP} title="XPSGR-9" />,
+      dataIndex: 'nineSymbolAmount',
+      key: 'nineSymbolAmount',
+      sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
+    },
+    {
+      title: <PointsTitle tip={SGR_6_TOOL_TIP} title="XPSGR-6" />,
+      dataIndex: 'sixSymbolAmount',
+      key: 'sixSymbolAmount',
+      sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
+    },
+    {
+      title: <PointsTitle tip={SGR_5_TOOL_TIP} title="XPSGR-5" />,
+      dataIndex: 'fiveSymbolAmount',
+      key: 'fiveSymbolAmount',
+      sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
+    },
+    {
+      title: <PointsTitle tip={SGR_4_TOOL_TIP} title="XPSGR-4" />,
+      dataIndex: 'fourSymbolAmount',
+      key: 'fourSymbolAmount',
+      sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
+    },
+    {
+      title: <PointsTitle tip={SGR_3_TOOL_TIP} title="XPSGR-3" />,
+      dataIndex: 'thirdSymbolAmount',
+      key: 'thirdSymbolAmount',
+      sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
+    },
+    {
+      title: <PointsTitle tip={SGR_2_TOOL_TIP} title="XPSGR-2" />,
       dataIndex: 'secondSymbolAmount',
       key: 'secondSymbolAmount',
       sorter: true,
+      sortDirections: ['descend', 'ascend', 'descend'],
       width: 180,
       render: (_, item) => {
         return <EarnAmountCount {...item} amount={item.secondSymbolAmount} className="text-base" />;
       },
     },
     {
-      title: (
-        <div className="flex items-center">
-          <Tooltip title={SGR_5_TOOL_TIP}>
-            <QuestionIconComp className="w-4 h-4 mr-1 cursor-pointer" width={16} height={16} />
-          </Tooltip>
-          <span>XPSGR-5</span>
-        </div>
-      ),
-      dataIndex: 'fiveSymbolAmount',
-      key: 'fiveSymbolAmount',
+      title: <PointsTitle tip={SGR_1_TOOL_TIP} title="XPSGR-1" />,
+      dataIndex: 'firstSymbolAmount',
+      key: 'firstSymbolAmount',
       sorter: true,
-      render: (amount) => {
-        const text = BigNumber(amount)
-          .dividedBy(10 ** 8)
-          .toNumber();
-        return <span className=" text-neutralPrimary text-base font-medium">{formatTokenPrice(text)}</span>;
-      },
+      sortDirections: ['descend', 'ascend', 'descend'],
+      render: (amount) => <EarnAmount amount={amount} />,
     },
   ];
 

--- a/src/pageComponents/ranking/hooks/useRankingService.ts
+++ b/src/pageComponents/ranking/hooks/useRankingService.ts
@@ -1,14 +1,12 @@
 import { useRequest } from 'ahooks';
 import { fetchRankingList } from 'api/rankingApi';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import useGetDappList from 'hooks/useGetDappList';
 import { sortType } from '..';
 import { decodeAddress, getOriginalAddress } from 'utils/addressFormatting';
 
 export function useRankingService() {
   const { data, run, loading } = useRequest(fetchRankingList, {
-    debounceWait: 300,
-    debounceLeading: true,
     manual: true,
     pollingInterval: 1000 * 60,
   });
@@ -19,10 +17,10 @@ export function useRankingService() {
   const [keyword, setKeyWord] = useState<string>('');
   const [currentPageSize, setCurrentPageSize] = useState<number>(10);
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [sortField, setSortField] = useState<string>(sortType.firstSymbolAmount);
+  const [sortField, setSortField] = useState<string>(sortType.elevenSymbolAmount);
   const [fieldOrder, setFieldOrder] = useState<string>();
 
-  const onSearch = () => {
+  const onSearch = useCallback(() => {
     const pageNumber = currentPageSize;
     const sortOption = !fieldOrder
       ? { sortingKeyWord: sortField }
@@ -42,7 +40,7 @@ export function useRankingService() {
       params.skipCount = 0;
     }
     run(params);
-  };
+  }, [currentPage, currentPageSize, dappName, fieldOrder, keyword, run, sortField]);
 
   const onRefresh = () => {
     onSearch();
@@ -50,7 +48,7 @@ export function useRankingService() {
 
   useEffect(() => {
     onSearch();
-  }, [keyword, dappName, currentPageSize, currentPage, fieldOrder]);
+  }, [onSearch]);
 
   useEffect(() => {
     setCurrentPage(1);
@@ -61,7 +59,7 @@ export function useRankingService() {
       item.rank = (currentPage - 1) * currentPageSize + index + 1;
       return item;
     });
-  }, [data]);
+  }, [currentPage, currentPageSize, data?.items]);
 
   useEffect(() => {
     dappList?.length && setDappName(dappList[0].dappId);

--- a/src/pageComponents/ranking/index.tsx
+++ b/src/pageComponents/ranking/index.tsx
@@ -14,7 +14,13 @@ import styles from './style.module.css';
 export enum sortType {
   'firstSymbolAmount' = 'FirstSymbolAmount',
   'secondSymbolAmount' = 'SecondSymbolAmount',
+  'thirdSymbolAmount' = 'ThirdSymbolAmount',
+  'fourSymbolAmount' = 'FourSymbolAmount',
   'fiveSymbolAmount' = 'FiveSymbolAmount',
+  'sixSymbolAmount' = 'SixSymbolAmount',
+  'nineSymbolAmount' = 'NineSymbolAmount',
+  'tenSymbolAmount' = 'TenSymbolAmount',
+  'elevenSymbolAmount' = 'ElevenSymbolAmount',
 }
 
 export default function RankingPage() {
@@ -104,7 +110,7 @@ export default function RankingPage() {
         }}
         onChange={({ field, order }) => {
           setFieldOrder(order);
-          setSortField(sortType[field] || sortType.firstSymbolAmount);
+          setSortField(sortType[field] || sortType.elevenSymbolAmount);
         }}
       />
     </section>

--- a/src/pageComponents/rankingDetail/comps/EarnList.tsx
+++ b/src/pageComponents/rankingDetail/comps/EarnList.tsx
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import { EarnAmountCount } from 'pageComponents/ranking/comps/EarnAmount';
+import { EarnAmountCount } from 'pageComponents/ranking/comps/EarnAmountDynamic';
 import { formatTokenPrice } from 'utils/format';
 
 interface IPointDetail {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -28,7 +28,7 @@ const makeStore = () => {
       getDefaultMiddleware({
         serializableCheck: false,
       }),
-    devTools: process.env.NODE_ENV !== 'production',
+    devTools: process.env.NEXT_PUBLIC_APP_ENV !== 'production',
   });
 
   return {


### PR DESCRIPTION
1. Add points types :3, 4, 6, 9, 10, 11, and put them in the following order: 11, 10, 9, 6, 5, 4, 3, 2, 1.
2. The ranking details page also adds the above types.
3. The ranking table is sorted by default by points 11 from highest to lowest.
close #19 Add points types to the ranking table